### PR TITLE
Include requirements.txt in the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
This fixes the problem of the sdist, as [currently published on PyPI](https://pypi.org/project/morphopy/0.7.2/#files), not being usable because `setup.py` reads requirements from `requirements.txt`, but `requirements.txt` is not included.

Before this PR:

```
$ gh repo clone berenslab/MorphoPy
$ cd MorphoPy
$ python3 -m build
[…]
FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'

ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```

After this PR:

```
$ python3 -m build
[…]
Successfully built morphopy-0.7.2.tar.gz and morphopy-0.7.2-py3-none-any.whl
$ tar -tzf dist/morphopy-0.7.2.tar.gz
morphopy-0.7.2/
morphopy-0.7.2/LICENSE
morphopy-0.7.2/MANIFEST.in
[…]
morphopy-0.7.2/requirements.txt
[…]
```