### PR TITLE
Do not require PyPI mock to build the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,8 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-import mock
 import sys
+from unittest import mock
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 MOCK_MODULES = ['numpy', 'scipy', 'scipy.io', 'scipy.ndimage', 'scipy.ndimage.filters', 'scipy.sparse', 'scipy.spatial', 'scipy.interpolate', 'scipy.signal', 'matplotlib', 'matplotlib.colors', 'matplotlib.pyplot', 'matplotlib.artist', 'matplotlib.font_manager', 'matplotlib.rcsetup', 'matplotlib.patches', 'matplotlib_scalebar.scalebar', 'matplotlib.offsetbox', 'pandas', 'seaborn', 'sklearn', 'sklearn.decomposition']
 for mod_name in MOCK_MODULES:


### PR DESCRIPTION
Instead of the [`mock` package from PyPI](https://pypi.org/project/mock/), we can (since Python 3.3) just use [`unittest.mock` from the standard library](https://docs.python.org/3/library/unittest.mock.html).