### PR TITLE
Update the intersphinx_mapping format

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,4 +83,4 @@ html_static_path = ['_static']
 
 htmlhelp_basename = 'MorphoPydoc'
 
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}


### PR DESCRIPTION
Fixes:

```
WARNING: The pre-Sphinx 1.0 'intersphinx_mapping' format is deprecated and will be removed in Sphinx 8. Update to the current format as described in the documentation. Hint: "intersphinx_mapping = {'<name>': ('http://docs.python.org/', None)}".https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping
```

See: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping

(This PR incidentally adds a newline to the last line of the file, which makes it a POSIXly valid text file – a side effect of editing in `vim`, and one I retained since the last line is the one I was editing.)