### PR TITLE
Fix gaussian window import path for current SciPy releases

### DIFF
--- a/morphopy/neurontree/utils.py
+++ b/morphopy/neurontree/utils.py
@@ -5,7 +5,8 @@ import numpy as np
 import pandas as pd
 import scipy
 from scipy.ndimage import gaussian_filter
-from scipy.signal import convolve2d, gaussian
+from scipy.signal import convolve2d
+from scipy.signal.windows import gaussian
 from scipy.sparse import coo_matrix
 from scipy.spatial import ConvexHull
 from sklearn.decomposition import PCA


### PR DESCRIPTION
Old: https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.signal.gaussian.html

New: https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.gaussian.html#scipy.signal.windows.gaussian

Fixes:

```
$ python3 -m venv _e
$ . _e/bin/activate
(_e) $ pip install morphopy
(_e) $ morphopy --help
Traceback (most recent call last):
  File "/home/ben/fedora/devel/python-morphopy/_e/bin/morphopy", line 5, in <module>
    from morphopy.MorphoPy import main
  File "/home/ben/fedora/devel/python-morphopy/_e/lib64/python3.12/site-packages/morphopy/MorphoPy.py", line 13, in <module>
    from morphopy.computation import file_manager
  File "/home/ben/fedora/devel/python-morphopy/_e/lib64/python3.12/site-packages/morphopy/computation/file_manager.py", line 3, in <module>
    import morphopy.neurontree.NeuronTree as nt
  File "/home/ben/fedora/devel/python-morphopy/_e/lib64/python3.12/site-packages/morphopy/neurontree/NeuronTree.py", line 19, in <module>
    from morphopy.neurontree.utils import (
  File "/home/ben/fedora/devel/python-morphopy/_e/lib64/python3.12/site-packages/morphopy/neurontree/utils.py", line 8, in <module>
    from scipy.signal import convolve2d, gaussian
ImportError: cannot import name 'gaussian' from 'scipy.signal' (/home/ben/fedora/devel/python-morphopy/_e/lib64/python3.12/site-packages/scipy/signal/__init__.py)
```