### PR TITLE
Pause release CI for now

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,6 +1,6 @@
 name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 
-on: push
+# on: push
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
release ci is broken. If someone needs to make a release, we should either do it manually or fix the ci.